### PR TITLE
Prevent git blame failures from stopping open in editor

### DIFF
--- a/lib/open-editor.js
+++ b/lib/open-editor.js
@@ -58,7 +58,6 @@ exports.openEditor = self.openEditor = function (data){
 	const repoPath = data.repoPath;
 	const absPath = data.absPath;
 	const gitref = data.gitref;
-	const lines = data.lines;
 	const editor = data.editor;
 	const path = data.path;
 	

--- a/lib/open-editor.js
+++ b/lib/open-editor.js
@@ -44,13 +44,18 @@ Try to use git blame to find the correct line.
 */
 
 self.normalizeLine = function (path,line,gitref,repoPath){
-	const cmd = ("git blame -L " + line + "," + line + " -n --reverse " + gitref + "..head -- " + path);
-	const output = cp.execSync(cmd,{cwd: repoPath,env: process.env}).toString();
-	// Uncomment the below line to look at the output format and command
-	// console.log "cmd",cmd,"output",output
-	if (output) {
-		return output.split(' ')[1];
-	};
+	try {
+		const cmd = ("git blame -L " + line + "," + line + " -n --reverse " + gitref + "..head -- " + path);
+		try {
+			const output = cp.execSync(cmd,{cwd: repoPath,env: process.env}).toString();
+		} catch (e) { };
+		// Uncomment the below line to look at the output format and command
+		console.log("cmd",cmd,"output",output);
+		if (output) {
+			return output.split(' ')[1];
+		};
+	} catch (e) { };
+	return console.log("normalize failed");
 };
 
 exports.openEditor = self.openEditor = function (data){

--- a/src/open-editor.imba
+++ b/src/open-editor.imba
@@ -34,12 +34,14 @@ The line might have changed since it became a snippet.
 Try to use git blame to find the correct line.
 ###
 def normalizeLine path,line,gitref,repoPath
-	const cmd = "git blame -L {line},{line} -n --reverse {gitref}..head -- {path}"
-	const output = cp.execSync(cmd, cwd: repoPath, env: process:env).toString()
-	# Uncomment the below line to look at the output format and command
-	# console.log "cmd",cmd,"output",output
-	if output
-		output.split(' ')[1]
+	try
+		const cmd = "git blame -L {line},{line} -n --reverse {gitref}..head -- {path}"
+		const output = try cp.execSync(cmd, cwd: repoPath, env: process:env).toString()
+		# Uncomment the below line to look at the output format and command
+		console.log "cmd",cmd,"output",output
+		if output
+			return output.split(' ')[1]
+	console.log "normalize failed"
 
 export def openEditor data
 	const startLine = data:startLine

--- a/src/open-editor.imba
+++ b/src/open-editor.imba
@@ -46,7 +46,6 @@ export def openEditor data
 	const repoPath = data:repoPath
 	const absPath = data:absPath
 	const gitref = data:gitref
-	const lines = data:lines
 	const editor = data:editor
 	const path = data:path
 


### PR DESCRIPTION
Noticed this stopped breaking when I tried opening a contextual snippet that was linked to a repository with some unstaged changes.

Also removed an unused constant from earlier.