### PR TITLE
Hide menu on Linux using ALT key

### DIFF
--- a/main.js
+++ b/main.js
@@ -198,6 +198,7 @@ async function setupApplication () {
   main.loadURL("https://" + HOST + initialUrl);
   devToolsLog(logQueue);
 
+  main.setAutoHideMenuBar(true);
   main.on('show',function(event){
     if(splash){
       splash.hide();


### PR DESCRIPTION
This let's you use the `ALT` key to toggle the menu bar on Linux, tested it on [Deepin](https://www.deepin.org/en/).