### PR TITLE
git: trim the text before performing the grep operation

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -593,6 +593,8 @@ GitRepo.prototype.checkTest = function (){
 };
 
 GitRepo.prototype.grep = async function (text){
+	// Trim the text so trailing newlines will not prevent a match.
+	text = text.trim();
 	
 	// find the last commit that is shared between local branch and upstream
 	// FIXME now always looking for the location relative to remote HEAD

--- a/src/git.imba
+++ b/src/git.imba
@@ -480,6 +480,8 @@ export class GitRepo < Git
 		return {a: 1, b: 2}
 
 	def grep text
+		# Trim the text so trailing newlines will not prevent a match.
+		text = text.trim()
 		
 		# find the last commit that is shared between local branch and upstream
 		# FIXME now always looking for the location relative to remote HEAD


### PR DESCRIPTION
This makes contextual snippets more stable for me. I tend to copy lines
in the terminal using `tail`, `head`, `cat`, etc. Some of them add new
lines which break the contextual snippet. After this change it works
much better for me.